### PR TITLE
have ncurses handle interrupt characters

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -9,7 +9,6 @@
 #include <sys/ioctl.h>
 #include <linux/vt.h>
 #include <unistd.h>
-#include <signal.h>
 /* ncurses */
 #include <form.h>
 /* pam */
@@ -46,9 +45,6 @@ int main(void)
 	char* username;
 	char* password;
 	char* cmd;
-	/* prevents CTRL+C from killing the process */
-	signal(SIGINT, SIG_IGN);
-	signal(SIGHUP, SIG_IGN);
 	/* gets desktop entries */
 	de_list = list_de();
 	de_props = de_list->props;

--- a/src/ncui.c
+++ b/src/ncui.c
@@ -30,7 +30,7 @@ void init_ncurses(FILE* desc)
 	ioctl(filedesc, VT_WAITACTIVE, LY_CONSOLE_TTY);
 	/* ncurses startup */
 	initscr();
-	cbreak();
+	raw();
 	noecho();
 }
 


### PR DESCRIPTION
As it was, didn't handle ^\ SIGQUIT or ^Z SIGTSTP.