### PR TITLE
Better handling of the creation of LY_CFG_SAVE and normalization of exit codes

### DIFF
--- a/src/lang.h
+++ b/src/lang.h
@@ -13,8 +13,9 @@
 #define LY_LANG_PASSWORD "password : "
 
 /* ioctl */
-#define LY_ERR_FD "Failed to create the console file descriptor"
-#define LY_ERR_FD_ADVICE "(ly probably wasn't run with enough privileges)"
+#define LY_ERR_FD_CONSOLE "Failed to create the console file descriptor"
+#define LY_ERR_FD_CONSOLE_ADVICE "(ly probably wasn't run with enough privileges)"
+#define LY_ERR_FD_CFG_SAVE "Failed to create the config file"
 
 /* pam */
 #define LY_ERR_PAM_BUF "Memory buffer error"

--- a/src/login.c
+++ b/src/login.c
@@ -370,7 +370,7 @@ const char* de_command, enum deserv_t display_server)
 				break;
 		}
 
-		exit(0);
+		exit(EXIT_SUCCESS);
 	}
 
 	/* waits for the de/shell to exit */
@@ -477,7 +477,7 @@ int xinitrc)
 	if(child == 0)
 	{
 		execl(pwd->pw_shell, pwd->pw_shell, "-c", cmd, NULL);
-		exit(0);
+		exit(EXIT_SUCCESS);
 	}
 
 	waitpid(child, &status, 0);
@@ -489,7 +489,7 @@ int xinitrc)
 	de_command, LY_CMD_X,
 	display_name, vt, getenv("XAUTHORITY"));
 	execve(pwd->pw_shell, argv, environ);
-	exit(0);
+	exit(EXIT_SUCCESS);
 }
 
 void launch_wayland(struct passwd* pwd, pam_handle_t* pam_handle,
@@ -507,7 +507,7 @@ void launch_shell(struct passwd* pwd, pam_handle_t* pam_handle)
 	strncpy(args + 1, ((pos = strrchr(pwd->pw_shell,
 	'/')) ? pos + 1 : pwd->pw_shell), sizeof(args) - 1);
 	execl(pwd->pw_shell, args, NULL);
-	exit(0);
+	exit(EXIT_SUCCESS);
 }
 
 void destroy_env(void)
@@ -594,7 +594,7 @@ void reset_terminal(struct passwd* pwd)
 	if(pid == 0)
 	{
 		execl(pwd->pw_shell, pwd->pw_shell, "-c", cmd, NULL);
-		exit(0);
+		exit(EXIT_SUCCESS);
 	}
 
 	waitpid(pid, &status, 0);

--- a/src/main.c
+++ b/src/main.c
@@ -60,7 +60,7 @@ int main(void)
 	{
 		fprintf(stderr, "%s\n", LY_ERR_FD_CONSOLE);
 		fprintf(stderr, "%s\n", LY_ERR_FD_CONSOLE_ADVICE);
-		return 0;
+		return EXIT_FAILURE;
 	}
 
 	/* create LY_CFG_SAVE if it doesn't exist yet */
@@ -68,7 +68,7 @@ int main(void)
 	if (!cfg_save)
 	{
 		fprintf(stderr, "%s: %s\n", LY_ERR_FD_CFG_SAVE, LY_CFG_SAVE);
-		return 0;
+		return EXIT_FAILURE;
 	}
 	fclose(cfg_save);
 
@@ -217,5 +217,5 @@ int main(void)
 	free_list(de_list);
 	end_form(&form);
 	endwin();
-	return 0;
+	return EXIT_SUCCESS;
 }

--- a/src/main.c
+++ b/src/main.c
@@ -58,10 +58,19 @@ int main(void)
 
 	if(!console)
 	{
-		fprintf(stderr, "%s\n", LY_ERR_FD);
-		fprintf(stderr, "%s\n", LY_ERR_FD_ADVICE);
+		fprintf(stderr, "%s\n", LY_ERR_FD_CONSOLE);
+		fprintf(stderr, "%s\n", LY_ERR_FD_CONSOLE_ADVICE);
 		return 0;
 	}
+
+	/* create LY_CFG_SAVE if it doesn't exist yet */
+	FILE* cfg_save = fopen(LY_CFG_SAVE, "ab+");
+	if (!cfg_save)
+	{
+		fprintf(stderr, "%s: %s\n", LY_ERR_FD_CFG_SAVE, LY_CFG_SAVE);
+		return 0;
+	}
+	fclose(cfg_save);
 
 	kernel_log(0);
 	/* initializes ncurses UI */
@@ -102,8 +111,7 @@ int main(void)
 					/* saves the username and DE if enabled */
 					if(LY_CFG_WRITE_SAVE)
 					{
-						FILE* file = fopen(LY_CFG_SAVE, "ab+");
-						file = fopen(LY_CFG_SAVE, "wb");
+						FILE* file = fopen(LY_CFG_SAVE, "wb");
 						fprintf(file, "%s\n%d", username, de_id);
 						fclose(file);
 					}

--- a/src/ncui.c
+++ b/src/ncui.c
@@ -40,9 +40,7 @@ void init_form(struct ncform* form, char** list, int max_de, int* de_id)
 	char line[LY_LIM_LINE_FILE];
 	char user[LY_LIM_LINE_FILE];
 	int de;
-	/* creates the file if it can't be found */
-	file = fopen(LY_CFG_SAVE, "ab+");
-	fclose(file);
+
 	/* opens the file */
 	file = fopen(LY_CFG_SAVE, "rb");
 	memset(user, '\0', LY_LIM_LINE_FILE);

--- a/src/utils.c
+++ b/src/utils.c
@@ -22,7 +22,7 @@ void kernel_log(int mode)
 	pid = fork();
 	if(pid < 0) {
 		perror("fork");
-		exit(1);
+		exit(EXIT_FAILURE);
 	}
 
 	if(pid == 0)
@@ -37,12 +37,12 @@ void kernel_log(int mode)
 		}
 		/* execl should not return */
 		perror("execl");
-		exit(1);
+		exit(EXIT_FAILURE);
 	}
 
 	waitpid(pid, &status, 0);
 	if(!WIFEXITED(status) || WEXITSTATUS(status))
-		exit(1);
+		exit(EXIT_FAILURE);
 }
 
 char* trim(char* s)


### PR DESCRIPTION
This simple PR "fixes" the initial segfault when `LY_CFG_SAVE` cannot be created, hence resolving #20.

I also took the liberty to normalize the exit codes by using `EXIT_SUCCESS` and `EXIT_FAILURE` instead of `0` or `1`. There already was and `EXIT_FAILURE` and it's certainly better to have the same everywhere.