### PR TITLE
Disable service popup messages

### DIFF
--- a/ly.service
+++ b/ly.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=ly ncurses display manager
-After=systemd-user-sessions.service
+After=systemd-user-sessions.service plymouth-quit-wait.service
 After=getty@tty2.service
 After=multi-user.target
 

--- a/ly.service
+++ b/ly.service
@@ -1,7 +1,8 @@
 [Unit]
 Description=ly ncurses display manager
-After=systemd-user-sessions.service plymouth-quit-wait.service
+After=systemd-user-sessions.service
 After=getty@tty2.service
+After=multi-user.target
 
 [Service]
 Type=simple


### PR DESCRIPTION
This change to ly.service resolves the problem with service messages
poping up over ly. #38 

It should work with all systemd default configurations but was only tested on Archlinux.