### PR TITLE
Ignore keystrokes that are not associated with a keysym

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -91,7 +91,7 @@ int main(void)
 	set_current_field(form.form, form.fields[6]);
 	form_driver(form.form, REQ_END_LINE);
 
-	while((input_key = wgetch(win.win)))
+	while((input_key = wgetch(win.win)) != ERR)
 	{
 		form.active = current_field(form.form);
 


### PR DESCRIPTION
The system maps these to a keysym with value 0, causing ly to terminate.
With this fix it shouldn't happen anymore

Fixes #21