### PR TITLE
Configurable tty number

### DIFF
--- a/src/login.c
+++ b/src/login.c
@@ -33,6 +33,8 @@
 #include "login.h"
 #include "desktop.h"
 
+extern int ly_console_tty;
+
 int login_conv(int num_msg, const struct pam_message** msg,
 struct pam_response** resp, void* appdata_ptr)
 {
@@ -105,8 +107,8 @@ const char* de_command, enum deserv_t display_server)
 	destroy_env();
 	display_id = get_free_display();
 	snprintf(display_name, sizeof(display_name), ":%d", display_id);
-	snprintf(tty_id, sizeof(tty_id), "%d", LY_CONSOLE_TTY);
-	snprintf(vt, sizeof(vt), "vt%d", LY_CONSOLE_TTY);
+	snprintf(tty_id, sizeof(tty_id), "%d", ly_console_tty);
+	snprintf(vt, sizeof(vt), "vt%d", ly_console_tty);
 	init_xdg(tty_id, display_name, display_server);
 	/* pam_start and error handling */
 	pam_result = pam_start(LY_SERVICE_NAME, username, &conv, &login_handle);

--- a/src/main.c
+++ b/src/main.c
@@ -25,6 +25,8 @@
 #define KEY_ENTER_ASCII 10
 #define KEY_BACKSPACE_ASCII 127
 
+int ly_console_tty;
+
 int main(void)
 {
 	FILE* console;
@@ -78,6 +80,23 @@ int main(void)
 	fclose(cfg_save);
 
 	kernel_log(0);
+	/* try to get console tty from environment */
+	{
+		char *console_tty_env;
+		console_tty_env = getenv("LY_CONSOLE_TTY");
+		if(console_tty_env){
+			ly_console_tty = atoi(console_tty_env);
+			if((ly_console_tty < 1) || (ly_console_tty > 99)){
+				/* Invalid value of the environment variable; defaults is used */
+				ly_console_tty = LY_CONSOLE_TTY;
+				fprintf(stderr, "LY_CONSOLE_TTY has invalid value, use default tty %d\n", ly_console_tty);
+			}
+		} else {
+			/* environment not defined */
+			ly_console_tty = LY_CONSOLE_TTY;
+			fprintf(stderr, "LY_CONSOLE_TTY not defined, use default tty %d\n", ly_console_tty);
+		}
+	}
 	/* initializes ncurses UI */
 	init_ncurses(console);
 	init_form(&form, de_names, de_count, &de_id);

--- a/src/ncui.c
+++ b/src/ncui.c
@@ -15,6 +15,8 @@
 #include "config.h"
 #include "utils.h"
 
+extern int ly_console_tty;
+
 size_t max(size_t a, size_t b)
 {
 	return (a > b) ? a : b;
@@ -26,8 +28,8 @@ void init_ncurses(FILE* desc)
 	/* required for ncurses */
 	putenv(LY_CONSOLE_TERM);
 	/* switches tty */
-	ioctl(filedesc, VT_ACTIVATE, LY_CONSOLE_TTY);
-	ioctl(filedesc, VT_WAITACTIVE, LY_CONSOLE_TTY);
+	ioctl(filedesc, VT_ACTIVATE, ly_console_tty);
+	ioctl(filedesc, VT_WAITACTIVE, ly_console_tty);
 	/* ncurses startup */
 	initscr();
 	raw();


### PR DESCRIPTION
The proposed changes allow to set the tty number through the environment variable LY_CONSOLE_TTY. Constant definition in the code still remain workable.