### PR TITLE
Define feature macros only on Linux

### DIFF
--- a/makefile
+++ b/makefile
@@ -4,6 +4,11 @@ CC=gcc
 #CC=tcc
 FLAGS=-std=c99 -pedantic -Wall -Werror=vla -Werror -g
 
+OS:=$(shell uname -s)
+ifeq ($(OS),Linux)
+	FLAGS+=-D_DEFAULT_SOURCE
+endif
+
 BIND=bin
 SRCD=src
 SUBD=sub

--- a/src/config.c
+++ b/src/config.c
@@ -1,4 +1,3 @@
-#define _XOPEN_SOURCE 700
 #include "config.h"
 #include "cylgom.h"
 #include "ini.h"

--- a/src/desktop.c
+++ b/src/desktop.c
@@ -1,4 +1,3 @@
-#define _XOPEN_SOURCE 700
 #include "desktop.h"
 #include "cylgom.h"
 #include "ini.h"

--- a/src/draw.c
+++ b/src/draw.c
@@ -1,4 +1,3 @@
-#define _XOPEN_SOURCE 700
 #include "draw.h"
 #include "cylgom.h"
 #include "termbox.h"

--- a/src/login.c
+++ b/src/login.c
@@ -1,6 +1,3 @@
-#define _XOPEN_SOURCE 700
-#define _DEFAULT_SOURCE
-
 #include "config.h"
 #include "login.h"
 #include "widgets.h"

--- a/src/util.c
+++ b/src/util.c
@@ -1,4 +1,3 @@
-#define _XOPEN_SOURCE 700
 #include "util.h"
 #include "config.h"
 #include "widgets.h"

--- a/src/widgets.c
+++ b/src/widgets.c
@@ -1,4 +1,3 @@
-#define _XOPEN_SOURCE 700
 #include "widgets.h"
 #include "cylgom.h"
 #include <string.h>


### PR DESCRIPTION
In preparation for the BSD support.

See also my relevant pull request to the termbox-next at:
https://github.com/cylgom/termbox-next/pull/1