### PR TITLE
Fix ioctl issues on DragonFly BSD and FreeBSD

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -14,7 +14,11 @@
 #include <unistd.h>
 #include <netdb.h>
 #include <sys/ioctl.h>
-#include <linux/vt.h>
+#if defined(__DragonFly__) || defined(__FreeBSD__)
+#  include <sys/consio.h>
+#else  /* assume Linux */
+#  include <linux/vt.h>
+#endif
 
 static char* hostname_backup = NULL;
 


### PR DESCRIPTION
* Include the correct headers on DragonFly BSD and FreeBSD.

* Use UTF-8 characters to draw the border on Linux.

* Use ioctl `KDGETLED` to get the keyboard NumLock/CapsLock states on BSD, while keep using `KDGKBLED` ioctl on Linux (see the `ioctl_console(2)` man page for more details).

* Use system macros instead of hard-coded magic numbers to extract the NumLock/CapsLock states, i.e., `LED_NUM` and `LED_CAP` on BSD, `K_NUMLOCK` and `K_CAPSLOCK` on Linux.

NOTE:
This patch only allows 'ly' to build fine on DragonFly BSD and FreeBSD (other *BSD not tested), and more works are needed to make 'ly' working fine on BSD.