### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ before going further:
 - mcookie
 - tput
 - shutdown
+- termbox
 
 ### Cloning and Compiling
 This repository uses submodules, to clone it properly please use


### PR DESCRIPTION
Termbox is mandatory to build and install ly, but not mentioned in README.md