### PR TITLE
i3wm - hide xorg start messages

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -286,7 +286,7 @@ void config_defaults()
 	config.tty = 2;
 	config.wayland_cmd = strdup("/etc/ly/wsetup.sh");
 	config.waylandsessions = strdup("/usr/share/wayland-sessions");
-	config.x_cmd = strdup("/usr/bin/X");
+	config.x_cmd = strdup("/usr/bin/X -keeptty > ~/.xorg.log 2>&1");
 	config.x_cmd_setup = strdup("/etc/ly/xsetup.sh");
 	config.xauth_cmd = strdup("/usr/bin/xauth");
 	config.xsessions = strdup("/usr/share/xsessions");


### PR DESCRIPTION
Hi!
I use [i3wm](https://i3wm.org/) and I really like **[ly DM](https://github.com/cylgom/ly)**, thanks for sharing.
However, xorg's start output gives the impression that something is wrong even though it is not. 
My proposal here is just to suppress it:

From:
```c
	config.x_cmd = strdup("/usr/bin/X");
```
To:
```c
	config.x_cmd = strdup("/usr/bin/X -keeptty > ~/.xorg.log 2>&1");
```

Thank you! :)