### PR TITLE
cosmetic changes + enter behavior

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -263,7 +263,7 @@ void config_defaults()
 	config.blank_box = true;
 	config.blank_password = false;
 	config.console_dev = strdup("/dev/console");
-	config.default_input = 2;
+	config.default_input = PASSWORD_INPUT;
 	config.fg = 9;
 	config.hide_borders = false;
 	config.input_len = 34;

--- a/src/config.h
+++ b/src/config.h
@@ -3,6 +3,12 @@
 
 #include "ctypes.h"
 
+enum INPUTS {
+	SESSION_SWITCH,
+	LOGIN_INPUT,
+	PASSWORD_INPUT,
+};
+
 struct lang
 {
 	char* capslock;

--- a/src/inputs.c
+++ b/src/inputs.c
@@ -115,6 +115,8 @@ void input_text(struct text* target, u64 len)
 	target->end = target->text;
 	target->visible_start = target->text;
 	target->len = len;
+	target->x = 0;
+	target->y = 0;
 }
 
 void input_desktop_free(struct desktop* target)

--- a/src/main.c
+++ b/src/main.c
@@ -47,7 +47,7 @@ void log_init(char** log)
 	log[DGN_NULL] = lang.err_null;
 	log[DGN_ALLOC] = lang.err_alloc;
 	log[DGN_BOUNDS] = lang.err_bounds;
-	log[DGN_DOMAIN] = lang.err_domain; 
+	log[DGN_DOMAIN] = lang.err_domain;
 	log[DGN_MLOCK] = lang.err_mlock;
 	log[DGN_XSESSIONS_DIR] = lang.err_xsessions_dir;
 	log[DGN_XSESSIONS_OPEN] = lang.err_xsessions_open;

--- a/src/main.c
+++ b/src/main.c
@@ -196,45 +196,43 @@ int main(int argc, char** argv)
 
 		if (event.type == TB_EVENT_KEY)
 		{
-			if (event.key == TB_KEY_F1)
+			switch (event.key)
 			{
+			case TB_KEY_F1:
 				shutdown = true;
+				run = false;
 				break;
-			}
-			else if (event.key == TB_KEY_F2)
-			{
+			case TB_KEY_F2:
 				reboot = true;
+				run = false;
 				break;
-			}
-			else if (event.key == TB_KEY_CTRL_C)
-			{
+			case TB_KEY_CTRL_C:
+				run = false;
 				break;
-			}
-			else if ((event.key == TB_KEY_ARROW_UP) && (active_input > 0))
-			{
-				--active_input;
-				update = true;
-			}
-			else if (((event.key == TB_KEY_ARROW_DOWN)
-				|| (event.key == TB_KEY_ENTER))
-				&& (active_input < 2))
-			{
-				++active_input;
-				update = true;
-			}
-			else if (event.key == TB_KEY_TAB)
-			{
+			case TB_KEY_ARROW_UP:
+				if (active_input > 0)
+				{
+					--active_input;
+					update = true;
+				}
+				break;
+			case TB_KEY_ARROW_DOWN:
+				if (active_input < 2)
+				{
+					++active_input;
+					update = true;
+				}
+				break;
+			case TB_KEY_TAB:
 				++active_input;
 
 				if (active_input > 2)
 				{
-					active_input = 0;
+					active_input = PASSWORD_INPUT;
 				}
-
 				update = true;
-			}
-			else if (event.key == TB_KEY_ENTER)
-			{
+				break;
+			case TB_KEY_ENTER:
 				save(&desktop, &login);
 				auth(&desktop, &login, &password, &buf);
 				update = true;
@@ -242,6 +240,8 @@ int main(int argc, char** argv)
 				if (dgn_catch())
 				{
 					++auth_fails;
+					// move focus back to password input
+					active_input = PASSWORD_INPUT;
 
 					if (dgn_output_code() != DGN_PAM)
 					{
@@ -256,13 +256,13 @@ int main(int argc, char** argv)
 				}
 
 				load(&desktop, &login);
-			}
-			else
-			{
+				break;
+			default:
 				(*input_handles[active_input])(
 					input_structs[active_input],
 					&event);
 				update = true;
+				break;
 			}
 		}
 	}


### PR DESCRIPTION
Hello,

I enjoy using ly as my DM so I thought I'll see if there's something I could do to contribute.

With this patch I moved processing the key events in the main loop from if-elses to switch, which feels more natural and is perhaps better readable. That changed the behavior of "Enter" a bit from "move one line lower" to "submit password", but I guess that's not terrible (I now move the cursor to the password field on auth fail)

I also wrapped the pam actions into pam_do() function so that the clean up happens in one spot.

See if you like any of this, I haven't coded in C for quite some time, but hopefully it's not all terrible :)