### PR TITLE
Allow passing the path to the configuration file as an argument

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -146,8 +146,12 @@ void lang_load()
 	}
 }
 
-void config_load()
+void config_load(const char *cfg_path)
 {
+	if (cfg_path == NULL)
+	{
+		cfg_path = INI_CONFIG;
+	}
 	// must be alphabetically sorted
 	struct configator_param map_no_section[] =
 	{
@@ -202,7 +206,7 @@ void config_load()
 	config.sections = sections;
 	config.sections_len = sections_len;
 
-	configator(&config, INI_CONFIG);
+	configator(&config, cfg_path);
 }
 
 void lang_defaults()

--- a/src/config.h
+++ b/src/config.h
@@ -101,7 +101,7 @@ extern struct config config;
 
 void config_handle_str(void* data, char** pars, const int pars_count);
 void lang_load();
-void config_load();
+void config_load(const char *cfg_path);
 void lang_defaults();
 void config_defaults();
 void lang_free();

--- a/src/main.c
+++ b/src/main.c
@@ -16,7 +16,7 @@
 #include <unistd.h>
 #include <stdlib.h>
 
-#define ARG_COUNT 5
+#define ARG_COUNT 7
 // things you can define:
 // GIT_VERSION_STRING
 // RUNIT
@@ -61,6 +61,11 @@ void log_init(char** log)
 	log[DGN_HOSTNAME] = lang.err_hostname;
 }
 
+void arg_config(void* data, char** pars, const int pars_count)
+{
+	*((char **)data) = *pars;
+}
+
 // ly!
 int main(int argc, char** argv)
 {
@@ -71,17 +76,18 @@ int main(int argc, char** argv)
 	config_defaults();
 	lang_defaults();
 
-	config_load();
-
 	if (strcmp(config.lang, "en") != 0)
 	{
 		lang_load();
 	}
 
+	char *config_path = NULL;
 	// parse args
 	const struct argoat_sprig sprigs[ARG_COUNT] =
 	{
 		{NULL, 0, NULL, NULL},
+		{"config", 0, &config_path, arg_config},
+		{"c", 0, &config_path, arg_config},
 		{"help", 0, NULL, arg_help},
 		{"h", 0, NULL, arg_help},
 		{"version", 0, NULL, arg_version},
@@ -105,6 +111,8 @@ int main(int argc, char** argv)
 		lang_free();
 		return 1;
 	}
+
+	config_load(config_path);
 
 	void* input_structs[3] =
 	{


### PR DESCRIPTION
Requires changes in https://github.com/cylgom/configator/pull/1

Signed-off-by: Roosembert Palacios <roosembert.palacios@epfl.ch>