### PR TITLE
login.c: Do not overwrite the PATH variable if config.path element is empty

### DIFF
--- a/src/login.c
+++ b/src/login.c
@@ -229,12 +229,15 @@ void env_init(struct passwd* pwd, const char* display_name)
 	setenv("DISPLAY", display_name, 1);
 	setenv("LANG", lang, 1);
 
-	// path
-	int ok = setenv("PATH", config.path, 1);
-
-	if (ok != 0)
+	// Set PATH if specified in the configuration
+	if (strlen(config.path))
 	{
-		dgn_throw(DGN_PATH);
+		int ok = setenv("PATH", config.path, 1);
+
+		if (ok != 0)
+		{
+			dgn_throw(DGN_PATH);
+		}
 	}
 }
 


### PR DESCRIPTION
This allows disabling the feature if PATH was already set (e.g. by the systemd session
slice) and the user wishes to honor that.

Signed-off-by: Roosembert Palacios <roosembert.palacios@epfl.ch>