### PR TITLE
Makefile: Add config option to allow specifying a separate data directory

### DIFF
--- a/makefile
+++ b/makefile
@@ -20,6 +20,9 @@ SUBD = sub
 RESD = res
 TESTD = tests
 
+DATADIR ?= ${DESTDIR}/etc/ly
+FLAGS+= -DDATADIR=\"$(DATADIR)\"
+
 INCL = -I$(SRCD)
 INCL+= -I$(SUBD)/ctypes
 INCL+= -I$(SUBD)/argoat/src
@@ -70,16 +73,17 @@ install: $(BIND)/$(NAME)
 	@echo "installing"
 	@install -dZ ${DESTDIR}/etc/ly
 	@install -DZ $(BIND)/$(NAME) -t ${DESTDIR}/usr/bin
-	@install -DZ $(RESD)/xsetup.sh -t ${DESTDIR}/etc/ly
-	@install -DZ $(RESD)/wsetup.sh -t ${DESTDIR}/etc/ly
 	@install -DZ $(RESD)/config.ini -t ${DESTDIR}/etc/ly
-	@install -dZ ${DESTDIR}/etc/ly/lang
-	@install -DZ $(RESD)/lang/* -t ${DESTDIR}/etc/ly/lang
+	@install -DZ $(RESD)/xsetup.sh -t $(DATADIR)
+	@install -DZ $(RESD)/wsetup.sh -t $(DATADIR)
+	@install -dZ $(DATADIR)/lang
+	@install -DZ $(RESD)/lang/* -t $(DATADIR)/lang
 	@install -DZ $(RESD)/ly.service -t ${DESTDIR}/usr/lib/systemd/system
 
 uninstall:
 	@echo "uninstalling"
 	@rm -rf ${DESTDIR}/etc/ly
+	@rm -rf $(DATADIR)
 	@rm -f ${DESTDIR}/usr/bin/ly
 	@rm -f ${DESTDIR}/usr/lib/systemd/system/ly.service
 

--- a/src/config.c
+++ b/src/config.c
@@ -9,7 +9,7 @@
 #include <unistd.h>
 
 #ifndef DEBUG
-	#define INI_LANG "/etc/ly/lang/%s.ini"
+	#define INI_LANG DATADIR "/lang/%s.ini"
 	#define INI_CONFIG "/etc/ly/config.ini"
 #else
 	#define INI_LANG "../res/lang/%s.ini"
@@ -284,10 +284,10 @@ void config_defaults()
 	config.shutdown_cmd = strdup("/sbin/shutdown -a now");
 	config.term_reset_cmd = strdup("/usr/bin/tput reset");
 	config.tty = 2;
-	config.wayland_cmd = strdup("/etc/ly/wsetup.sh");
+	config.wayland_cmd = strdup(DATADIR "/wsetup.sh");
 	config.waylandsessions = strdup("/usr/share/wayland-sessions");
 	config.x_cmd = strdup("/usr/bin/X");
-	config.x_cmd_setup = strdup("/etc/ly/xsetup.sh");
+	config.x_cmd_setup = strdup(DATADIR "/xsetup.sh");
 	config.xauth_cmd = strdup("/usr/bin/xauth");
 	config.xsessions = strdup("/usr/share/xsessions");
 }


### PR DESCRIPTION
This allows the user to specify a different directory to store static files, such as
translations and other resources.

Signed-off-by: Roosembert Palacios <roosembert.palacios@epfl.ch>