### PR TITLE
Remove /usr/bin/env from default path

### DIFF
--- a/res/config.ini
+++ b/res/config.ini
@@ -57,7 +57,7 @@
 #min_refresh_delta = 5
 
 # default path
-#path = /sbin:/bin:/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/bin/env
+#path = /sbin:/bin:/usr/local/sbin:/usr/local/bin:/usr/bin
 
 # command executed when pressing F2
 #restart_cmd = /sbin/shutdown -r now

--- a/src/config.c
+++ b/src/config.c
@@ -280,7 +280,7 @@ void config_defaults()
 	config.max_password_len = 255;
 	config.mcookie_cmd = strdup("/usr/bin/mcookie");
 	config.min_refresh_delta = 5;
-	config.path = strdup("/sbin:/bin:/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/bin/env");
+	config.path = strdup("/sbin:/bin:/usr/local/sbin:/usr/local/bin:/usr/bin");
 	config.restart_cmd = strdup("/sbin/shutdown -r now");
 	config.save = true;
 	config.save_file = strdup("/etc/ly/save");


### PR DESCRIPTION
The path variable should only contains directories, and `/usr/bin/env` is a file.
While shells will generally ignore non-directories in the path, other software doesn't. For example `rkhunter` raises an error.