### PR TITLE
Add Wayland specifier to session names

### DIFF
--- a/res/config.ini
+++ b/res/config.ini
@@ -83,6 +83,9 @@
 # wayland setup command
 #wayland_cmd = /etc/ly/wsetup.sh
 
+# add wayland specifier to session names
+#wayland_specifier = false
+
 # wayland desktop environments
 #waylandsessions = /usr/share/wayland-sessions
 

--- a/src/config.c
+++ b/src/config.c
@@ -184,6 +184,7 @@ void config_load(const char *cfg_path)
 		{"term_reset_cmd", &config.term_reset_cmd, config_handle_str},
 		{"tty", &config.tty, config_handle_u8},
 		{"wayland_cmd", &config.wayland_cmd, config_handle_str},
+		{"wayland_specifier", &config.wayland_specifier, config_handle_bool},
 		{"waylandsessions", &config.waylandsessions, config_handle_str},
 		{"x_cmd", &config.x_cmd, config_handle_str},
 		{"x_cmd_setup", &config.x_cmd_setup, config_handle_str},
@@ -289,6 +290,7 @@ void config_defaults()
 	config.term_reset_cmd = strdup("/usr/bin/tput reset");
 	config.tty = 2;
 	config.wayland_cmd = strdup(DATADIR "/wsetup.sh");
+	config.wayland_specifier = false;
 	config.waylandsessions = strdup("/usr/share/wayland-sessions");
 	config.x_cmd = strdup("/usr/bin/X");
 	config.x_cmd_setup = strdup(DATADIR "/xsetup.sh");

--- a/src/config.h
+++ b/src/config.h
@@ -89,6 +89,7 @@ struct config
 	char* term_reset_cmd;
 	u8 tty;
 	char* wayland_cmd;
+	bool wayland_specifier;
 	char* waylandsessions;
 	char* x_cmd;
 	char* x_cmd_setup;

--- a/src/utils.c
+++ b/src/utils.c
@@ -95,6 +95,19 @@ void desktop_crawl(
 		strncat(path, dir_info->d_name, (sizeof (path)) - 1);
 		configator(&desktop_config, path);
 
+		// if these are wayland sessions, add " (Wayland)" to their names,
+		// as long as their names don't already contain that string
+		if (server == DS_WAYLAND && config.wayland_specifier)
+		{
+			const char wayland_specifier[] = " (Wayland)";
+			if (strstr(name, wayland_specifier) == NULL)
+			{
+				name = realloc(name, (strlen(name) + sizeof(wayland_specifier) + 1));
+				// using strcat is safe because the string is constant
+				strcat(name, wayland_specifier);
+			}
+		}
+
 		if ((name != NULL) && (exec != NULL))
 		{
 			input_desktop_add(target, name, exec, server);


### PR DESCRIPTION
This PR is related to issue #129, adding a config option that makes ly add a " (Wayland)" specifier to Wayland session names, the way SDDM, for example, does. This this makes it possible to differentiate Plasma on Xorg from Plasma on Wayland, for example.

I am unsure whether I should verify anything regarding the size of the "name" string, given that I simply concatenate the strings. I had added a realloc call to make it bigger, but it seems that argoat + configator don't use any dynamic allocations, so it wouldn't be the correct way of doing this.

In the interest of future proofing, do you believe it would be worth it to add an option for a Xorg specifier as well?