### PR TITLE
Make the project compilable with clang.

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,7 +1,7 @@
 NAME = ly
 CC = gcc
 FLAGS = -std=c99 -pedantic -g
-FLAGS+= -Wall -Wno-unused-parameter -Wextra -Werror=vla -Werror
+FLAGS+= -Wall -Wextra -Werror=vla -Wno-unused-parameter
 #FLAGS+= -DDEBUG
 FLAGS+= -DGIT_VERSION_STRING=\"$(shell git describe --long --tags | sed 's/\([^-]*-g\)/r\1/;s/-/./g')\"
 LINK = -lpam -lxcb

--- a/src/login.c
+++ b/src/login.c
@@ -431,7 +431,7 @@ void shell(struct passwd* pwd)
 		pos = pwd->pw_shell;
 	}
 
-	strncpy(args + 1, pos, 1024);
+	strncpy(args + 1, pos, 1023);
 	execl(pwd->pw_shell, args, NULL);
 }
 
@@ -672,3 +672,4 @@ void auth(
 		pam_diagnose(ok, buf);
 	}
 }
+


### PR DESCRIPTION
Clang generates more warning messages, such as pointing out a lack
of newline at end of file and issues with the size of a strncopy.

Moving -Wno-unused-parameter to the end of the flags avoids it being
overwritten by -Wextra.

Removing -Werror avoids compilation errors that may arise from new
compiler warnings that might come from newer versions of compilers.

Additionally, the -Werror flag made clang error out when compiling ly before the warnings it detected were corrected.