### PR TITLE
Unset DISPLAY variable for wayland

### DIFF
--- a/res/wsetup.sh
+++ b/res/wsetup.sh
@@ -6,6 +6,7 @@
 # Copyright (C) 2001-2005 Oswald Buddenhagen <ossi@kde.org>
 
 # Note that the respective logout scripts are not sourced.
+unset DISPLAY
 case $SHELL in
   */bash)
     [ -z "$BASH" ] && exec $SHELL $0 "$@"


### PR DESCRIPTION
See #167 
This is the fix that I currently use to get ly to work with sway. I am not sure if this is the proper way to implement it as I have only tested it on bash and zsh. Also to note is that it does not fix the problem of XDG_SESSION_TYPE being set to `tty`