### PR TITLE
fix hidden cursor after logout

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -264,6 +264,7 @@ int main(int argc, char** argv)
 				}
 
 				load(&desktop, &login);
+				system("tput cnorm");
 				break;
 			default:
 				(*input_handles[active_input])(


### PR DESCRIPTION
the fix is based on [Cursor disappears when running `top -n1 | head`](https://unix.stackexchange.com/questions/469770/cursor-disappears-when-running-top-n1-head)

fixes #118 