### PR TITLE
Fixes segfault when environment does not set LANG

### DIFF
--- a/src/login.c
+++ b/src/login.c
@@ -227,7 +227,10 @@ void env_init(struct passwd* pwd)
 	setenv("SHELL", pwd->pw_shell, 1);
 	setenv("USER", pwd->pw_name, 1);
 	setenv("LOGNAME", pwd->pw_name, 1);
-	setenv("LANG", lang, 1);
+	if (lang != NULL)
+	{
+		setenv("LANG", lang, 1);
+	}
 
 	// Set PATH if specified in the configuration
 	if (strlen(config.path))
@@ -530,7 +533,7 @@ void auth(
 	if (pwd->pw_shell[0] == '\0')
 	{
 		setusershell();
-		
+
 		char* shell = getusershell();
 
 		if (shell != NULL)
@@ -551,7 +554,7 @@ void auth(
 
 	if (pid == 0)
 	{
-		// set user info 
+		// set user info
 		ok = initgroups(pwd->pw_name, pwd->pw_gid);
 
 		if (ok != 0)
@@ -657,24 +660,23 @@ void auth(
 
 	// close pam session
 	ok = pam_do(pam_close_session, handle, 0, buf);
-	
+
 	if (ok != PAM_SUCCESS)
 	{
 		return;
 	}
 
 	ok = pam_do(pam_setcred, handle, PAM_DELETE_CRED, buf);
-	
+
 	if (ok != PAM_SUCCESS)
 	{
 		return;
 	}
 
 	ok = pam_end(handle, 0);
-	
+
 	if (ok != PAM_SUCCESS)
 	{
 		pam_diagnose(ok, buf);
 	}
 }
-


### PR DESCRIPTION
Fixes #191 by performing a null check before calling `setenv()`. A call to `setenv()` will segfault when its second argument (the variable value) is `NULL`. On some systems, `LANG` is not defined before the user logs in, so this is fixed by only exporting `LANG` if it is already defined (i.e. not `NULL`).

This change conforms to the POSIX specification. POSIX does not require `LANG` to be initialized at the time of login, like it does for variables such as `HOME`.