### PR TITLE
Add more details to the Debian dependencies

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -16,7 +16,7 @@ Ly is a lightweight TUI (ncurses-like) display manager for Linux and BSD.
  - tput
  - shutdown
 
-On Debian-based distros running `apt install build-essential libpam0g-dev libxcb-xkb-dev` should install all the dependencies for you.
+On Debian-based distros running `apt install build-essential libpam0g-dev libxcb-xkb-dev` as root should install all the dependencies for you.
 
 ## Support
 The following desktop environments were tested with success

--- a/readme.md
+++ b/readme.md
@@ -16,8 +16,7 @@ Ly is a lightweight TUI (ncurses-like) display manager for Linux and BSD.
  - tput
  - shutdown
 
-### Debian-based distros
- - libpam0g-dev
+On Debian-based distros running `apt install build-essential libpam0g-dev libxcb-xkb-dev` should install all the dependencies for you.
 
 ## Support
 The following desktop environments were tested with success


### PR DESCRIPTION
Instead of saying Debian-based distros need `libpam0g-dev` or whatever I just put an `apt` command that downloads all the dependencies (build-essential, libpam0g-dev, libxcb-xkb-dev).